### PR TITLE
Disable h2

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -475,9 +475,14 @@ function Server(compiler, options) {
     options.https.key = options.https.key || fakeCert;
     options.https.cert = options.https.cert || fakeCert;
 
+    /**
+     * The issue is that node v10+ doesn't support spdy,
+     * and it's not possible in this version the pass the correct option in order to disable h2,
+     * on newer webpack-dev-server versions this issue is resolved - sorry for the hack!
+     */
     if (!options.https.spdy) {
       options.https.spdy = {
-        protocols: ['h2', 'http/1.1']
+        protocols: ['http/1.1']
       };
     }
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,15 @@
 {
-  "name": "webpack-dev-server",
-  "version": "2.11.3",
-  "description": "Serves a webpack app. Updates the browser on changes.",
+  "name": "webpack-dev-server-without-h2",
+  "version": "2.11.4",
+  "description": "An hack for disabling http2 for webpack-dev-server v2.11 for node > v10",
   "license": "MIT",
   "repository": "webpack/webpack-dev-server",
-  "author": "Tobias Koppers @sokra",
+  "author": "Ron Lavi",
   "homepage": "https://github.com/webpack/webpack-dev-server",
   "maintainers": [
     {
-      "name": "Andrew Powell",
-      "email": "andrew@shellscape.org",
-      "url": "shellscape.org"
+      "name": "Ron Lavi",
+      "email": "1ronlavi@gmail.com"
     }
   ],
   "main": "lib/Server.js",


### PR DESCRIPTION
The issue is that node v10+ doesn't support spdy,
and it's not possible in this version the pass the correct option in order to disable h2,
on newer webpack-dev-server versions this issue is resolved - sorry for the hack!
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
