### PR TITLE
Fix overlay Entities is not a constructor

### DIFF
--- a/client-src/default/overlay.js
+++ b/client-src/default/overlay.js
@@ -4,9 +4,7 @@
 // They, in turn, got inspired by webpack-hot-middleware (https://github.com/glenjamin/webpack-hot-middleware).
 
 const ansiHTML = require('ansi-html');
-const Entities = require('html-entities').AllHtmlEntities;
-
-const entities = new Entities();
+const Entities = require('html-entities');
 
 const colors = {
   reset: ['transparent', 'transparent'],
@@ -101,7 +99,7 @@ function showMessageOverlay(message) {
     div.innerHTML = `<span style="color: #${
       colors.red
     }">Failed to compile.</span><br><br>${
-      ansiHTML(entities.encode(message))}`;
+      ansiHTML(Entities.encode(message))}`;
   });
 }
 

--- a/examples/cli/overlay/webpack.config.js
+++ b/examples/cli/overlay/webpack.config.js
@@ -6,5 +6,11 @@ const { setup } = require('../../util');
 
 module.exports = setup({
   context: __dirname,
-  entry: './app.js'
+  entry: './app.js',
+  devServer: {
+    overlay: {
+      warnings: true,
+      errors: true
+    }
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5228,9 +5228,9 @@
       "dev": true
     },
     "html-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "html-minifier": {
       "version": "3.5.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "debug": "^3.1.0",
     "del": "^3.0.0",
     "express": "^4.16.2",
-    "html-entities": "^1.2.0",
+    "html-entities": "2.3.3",
     "http-proxy-middleware": "^0.19.1",
     "import-local": "^1.0.0",
     "internal-ip": "1.2.0",


### PR DESCRIPTION
to test:
```
npm install
npm run prepublish 
cd examples/cli/overlay
npm run webpack-dev-server -- --open 
```
uncomment  the lines in `examples/cli/overlay/app.js`
if you see an error in the page and not only in the console it means its working